### PR TITLE
Доработки для macos и обратной связи

### DIFF
--- a/SwiftUI-Days.xcodeproj/project.pbxproj
+++ b/SwiftUI-Days.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.13;
+				MARKETING_VERSION = 1.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.oleg991.SwiftUI-Days";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -628,7 +628,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.13;
+				MARKETING_VERSION = 1.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.oleg991.SwiftUI-Days";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/SwiftUI-Days/Screens/More/MoreScreen.swift
+++ b/SwiftUI-Days/Screens/More/MoreScreen.swift
@@ -4,7 +4,10 @@ struct MoreScreen: View {
     @Environment(\.locale) private var locale
     @Environment(\.analyticsService) private var analytics
     @Environment(AppSettings.self) private var appSettings
-    private var isRunningOnMac: Bool { ProcessInfo.processInfo.isiOSAppOnMac }
+    private var isRunningOnMac: Bool {
+        ProcessInfo.processInfo.isiOSAppOnMac
+    }
+
     private let appId = "id6744068216"
 
     var body: some View {

--- a/SwiftUI-Days/Screens/More/MoreScreen.swift
+++ b/SwiftUI-Days/Screens/More/MoreScreen.swift
@@ -4,6 +4,7 @@ struct MoreScreen: View {
     @Environment(\.locale) private var locale
     @Environment(\.analyticsService) private var analytics
     @Environment(AppSettings.self) private var appSettings
+    private var isRunningOnMac: Bool { ProcessInfo.processInfo.isiOSAppOnMac }
     private let appId = "id6744068216"
 
     var body: some View {
@@ -12,11 +13,14 @@ struct MoreScreen: View {
                 ZStack {
                     Spacer().containerRelativeFrame([.vertical])
                     VStack(spacing: 16) {
-                        ViewThatFits(in: .horizontal) {
-                            horizontalLayout
+                        if isRunningOnMac {
                             verticalLayout
+                        } else {
+                            ViewThatFits(in: .horizontal) {
+                                horizontalLayout
+                                verticalLayout
+                            }
                         }
-                        .daysButtonStyle()
                         appVersionText
                     }
                 }
@@ -43,6 +47,7 @@ struct MoreScreen: View {
             }
             githubButton
         }
+        .daysButtonStyle()
     }
 
     private var verticalLayout: some View {
@@ -55,13 +60,17 @@ struct MoreScreen: View {
             shareAppButton
             githubButton
         }
+        .daysButtonStyle()
     }
 
+    @ViewBuilder
     private var appThemeIconButton: some View {
-        NavigationLink(.appThemeAndIcon) {
-            ThemeIconScreen(analytics: analytics)
+        if !isRunningOnMac {
+            NavigationLink(.appThemeAndIcon) {
+                ThemeIconScreen(analytics: analytics)
+            }
+            .accessibilityIdentifier("appThemeIconButton")
         }
-        .accessibilityIdentifier("appThemeIconButton")
     }
 
     private var appDataButton: some View {
@@ -73,7 +82,7 @@ struct MoreScreen: View {
 
     @ViewBuilder
     private var privacyButton: some View {
-        if !ProcessInfo.processInfo.isiOSAppOnMac {
+        if !isRunningOnMac {
             NavigationLink(.privacy) {
                 PrivacyScreen()
             }

--- a/SwiftUI-Days/Screens/More/MoreScreen.swift
+++ b/SwiftUI-Days/Screens/More/MoreScreen.swift
@@ -73,11 +73,11 @@ struct MoreScreen: View {
 
     @ViewBuilder
     private var privacyButton: some View {
-        #if !os(macOS)
-        NavigationLink(.privacy) {
-            PrivacyScreen()
+        if !ProcessInfo.processInfo.isiOSAppOnMac {
+            NavigationLink(.privacy) {
+                PrivacyScreen()
+            }
         }
-        #endif
     }
 
     private var feedbackButton: some View {

--- a/SwiftUI-Days/Services/FeedbackSender.swift
+++ b/SwiftUI-Days/Services/FeedbackSender.swift
@@ -14,14 +14,29 @@ enum FeedbackSender {
     }
 
     private enum Feedback {
-        static let subject = "\(ProcessInfo.processInfo.processName): Обратная связь"
-        static let body = """
-            Версия iOS: \(ProcessInfo.processInfo.operatingSystemVersionString)
-            Версия приложения: \((Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "1")
-            ---
-            Что можно улучшить в приложении?
-            \n
-        """
+        private static var processInfo: ProcessInfo {
+            ProcessInfo.processInfo
+        }
+
+        static let subject = "\(processInfo.processName): Обратная связь"
+
+        static var body: String {
+            var platformName: String {
+                let idiom = switch UIDevice.current.userInterfaceIdiom {
+                case .pad: "iPadOS"
+                default: "iOS"
+                }
+                return processInfo.isiOSAppOnMac ? "macOS" : idiom
+            }
+            return """
+                \(platformName): \(processInfo.operatingSystemVersionString)
+                Версия приложения: \((Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "1")
+                ---
+                Что можно улучшить в приложении?
+                \n
+            """
+        }
+
         static let recipient = "starker.words-01@icloud.com"
     }
 }


### PR DESCRIPTION
- Настройки темы, иконки и размытия записей для macOS убраны (тема автоматически настраивается системой, иконку менять не позволяет ограничение режима совместимости с iPad, а размытие записей требует бойлерплейт ради одной платформы)
- В письме для обратной связи подставляется корректная платформа (раньше всегда было iOS, теперь будет фактическая платформа - iOS/iPadOS/macOS)