### PR TITLE
Релиз 1.14.2

### DIFF
--- a/SwiftUI-Days.xcodeproj/project.pbxproj
+++ b/SwiftUI-Days.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.14.1;
+				MARKETING_VERSION = 1.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.oleg991.SwiftUI-Days";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -628,7 +628,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.14.1;
+				MARKETING_VERSION = 1.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.oleg991.SwiftUI-Days";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/SwiftUI-Days/Screens/Main/ListItemView.swift
+++ b/SwiftUI-Days/Screens/Main/ListItemView.swift
@@ -1,8 +1,19 @@
 import SwiftUI
 
 struct ListItemView: View {
-    @Environment(\.currentDate) private var currentDate
-    let item: Item
+    struct Content {
+        let title: String
+        let colorTag: Color?
+        let daysCount: String
+
+        init(item: Item, currentDate: Date) {
+            title = item.title
+            colorTag = item.colorTag
+            daysCount = item.makeDaysCount(to: currentDate)
+        }
+    }
+
+    let content: Content
 
     var body: some View {
         ViewThatFits {
@@ -15,20 +26,20 @@ struct ListItemView: View {
 
     @ViewBuilder
     private var colorTagView: some View {
-        if let colorTag = item.colorTag {
+        if let colorTag = content.colorTag {
             colorTag.frame(width: 16, height: 16)
                 .clipShape(.circle)
         }
     }
 
     private var titleView: some View {
-        Text(item.title)
+        Text(content.title)
             .lineLimit(2)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var daysCountView: some View {
-        Text(item.makeDaysCount(to: currentDate))
+        Text(content.daysCount)
             .multilineTextAlignment(.trailing)
             .contentTransition(.numericText())
     }

--- a/SwiftUI-Days/Screens/Main/MainScreen+ListView.swift
+++ b/SwiftUI-Days/Screens/Main/MainScreen+ListView.swift
@@ -25,8 +25,9 @@ extension MainScreen {
         var body: some View {
             List {
                 ForEach(items) { item in
+                    let content = ListItemView.Content(item: item, currentDate: currentDate)
                     NavigationLink(value: item) {
-                        ListItemView(item: item)
+                        ListItemView(content: content)
                     }
                     .swipeActions {
                         DaysDeleteButton {

--- a/SwiftUI-DaysTests/ListItemViewContentTests.swift
+++ b/SwiftUI-DaysTests/ListItemViewContentTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+@testable import SwiftUI_Days
+import Testing
+
+@Suite("Снапшот контента строки списка")
+struct ListItemViewContentTests {
+    private let calendar = Calendar.current
+
+    @Test("Снимок сохраняет исходные значения и не меняется после мутаций модели")
+    func snapshotKeepsOriginalValues() throws {
+        let now = Date.now
+        let oneDayAgo = try #require(calendar.date(byAdding: .day, value: -1, to: now))
+        let item = Item(
+            title: "Исходный заголовок",
+            details: "Описание",
+            timestamp: oneDayAgo,
+            colorTag: .red,
+            displayOption: .day
+        )
+        let expectedDaysCount = item.makeDaysCount(to: now)
+
+        let content = ListItemView.Content(item: item, currentDate: now)
+
+        item.title = "Измененный заголовок"
+        item.colorTag = nil
+        item.displayOption = .monthDay
+
+        #expect(content.title == "Исходный заголовок")
+        #expect(content.colorTag != nil)
+        #expect(content.daysCount == expectedDaysCount)
+    }
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,6 +52,13 @@ def asc_key
   @asc_key ||= load_app_store_connect_api_key
 end
 
+def latest_crashlytics_upload_symbols_binary
+  candidates = Dir["#{Dir.home}/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols"]
+  return nil if candidates.empty?
+
+  candidates.max_by { |path| File.mtime(path) }
+end
+
 platform :ios do
   desc "Сгенерировать новые локализованные скриншоты"
   lane :screenshots do
@@ -142,6 +149,19 @@ platform :ios do
       output_directory: "fastlane/builds",
       output_name: ARTIFACT_OUTPUT_NAME,
       xcargs: "-allowProvisioningUpdates"
+    )
+
+    dsym_output_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+    UI.user_error!("Не найден путь к dSYM после build_app") if dsym_output_path.to_s.empty?
+    UI.user_error!("Файл dSYM не найден: #{dsym_output_path}") unless File.exist?(dsym_output_path)
+
+    upload_symbols_binary = latest_crashlytics_upload_symbols_binary
+    UI.user_error!("Не найден Crashlytics upload-symbols binary в DerivedData") if upload_symbols_binary.nil?
+
+    upload_symbols_to_crashlytics(
+      dsym_path: dsym_output_path,
+      gsp_path: "SwiftUI-Days/GoogleService-Info.plist",
+      binary_path: upload_symbols_binary
     )
 
     upload_to_testflight(


### PR DESCRIPTION
- **Рефакторинг `ListItemView`** — вынесены данные строки в иммутабельный `struct Content` (title, colorTag, daysCount), который создаётся один раз в `MainScreen+ListView` и передаётся в `ListItemView`. Это устраняет зависимость от `@Environment(\.currentDate)` внутри `ListItemView` и гарантирует, что снимок данных строки не меняется при мутациях модели `Item`
- **Новый тест `ListItemViewContentTests`** — проверяет, что `ListItemView.Content` сохраняет исходные значения и не реагирует на последующие изменения модели `Item` (title, colorTag, displayOption)
- **Fail-safe загрузка dSYM в Crashlytics (Fastfile)** — добавлена функция `latest_crashlytics_upload_symbols_binary`, которая ищет бинарник `upload-symbols` в DerivedData. После `build_app` добавлены проверки наличия dSYM-файла и бинарника, а также вызов `upload_symbols_to_crashlytics` с явными путями к dSYM и `GoogleService-Info.plist`